### PR TITLE
Allow calling colors by name

### DIFF
--- a/Firmware/stealthburner_leds_alt.cfg
+++ b/Firmware/stealthburner_leds_alt.cfg
@@ -1,0 +1,231 @@
+# Macros for setting the status leds on the Voron StealthBurner toolhead (or for any neopixel-type leds).
+#
+# You will need to configure a neopixel (or other addressable led, such as dotstar). See
+# https://www.klipper3d.org/Config_Reference.html#neopixel for configuration details.
+
+
+#####################################
+#           INSTRUCTIONS            #
+#####################################
+# How to use all this stuff:
+#
+#     1.  Copy this .cfg file into your Klipper config directory and then add [include stealthburner_leds.cfg]
+#         to the top of your printer.cfg in order to register the LEDs and macros with Klipper.
+#     2.  Define your LEDs by editing [neopixel sb_leds] below and entering the data pin from your control board
+#         as well as the color order.
+#
+#           Note: RGB and RGBW are different and must be defined explicitly.  RGB and RGBW are also not able to 
+#                 be mix-and-matched in the same chain. A separate data line would be needed for proper functioning.
+#
+#                 RGBW LEDs will have a visible yellow-ish phosphor section to the chip.  If your LEDs do not have
+#                 this yellow portion, you have RGB LEDs.
+#
+#     3.  Save your config and restart Klipper.
+#
+#           Note: We set RED and BLUE to 1.0 to make it easier for users and supporters to detect 
+#                 misconfigurations or miswiring. The default color format is for Neopixels with a dedicated 
+#                 white LED. On startup, all three SB LEDs should light up.
+#
+#                 If you get random colors across your LEDs, change the color_order to GRB and restart. Then
+#                 omit the W for each suggested color_order in the next paragraph.
+#
+#                 If you get MAGENTA, your  color order is correct. If you get CYAN, you need to use RGBW. If
+#                 you get YELLOW, you need to use BRGW (note that BRG is only supported in the latest Klipper
+#                 version).
+#
+#     4.  Once you have confirmed that the LEDs are set up correctly, you must now decide where you want 
+#         these macros called up...which means adding them to your existing gcode macros.  NOTHING will happen
+#         unless you add the STATUS_????? macros to your existing gcode macros.  
+#
+#           Example: add STATUS_LEVELING to the beginning of your QGL gcode macro, and then add STATUS_READY 
+#                    to the end of it to set the logo LED and nozzle LEDs back to the `ready` state.
+#
+#           Example: add STATUS_CLEANING to the beginning of your nozzle-cleaning macro, and then STATUS_READY
+#                    to the end of it to return the LEDs back to `ready` state.
+#
+#     5.  Feel free to change colors of each macro, create new ones if you have a need to.  The macros provided below
+#         are just an example of what is possible.  If you want to try some more complex animations, you will most
+#         likely have to use WLED with Moonraker and a small micro-controller 
+#
+#####################################
+#       END INSTRUCTRUCTIONS        #
+#####################################
+
+[neopixel sb_leds]
+pin: 'enter_your_led_data_pin_name'
+#   The pin connected to the neopixel. This parameter must be provided.
+chain_count: 3
+#   The number of Neopixel chips that are "daisy chained" to the
+#   provided pin. The default is 1 (which indicates only a single
+#   Neopixel is connected to the pin).
+color_order: GRBW
+#   Set the pixel order required by the LED hardware. Options are GRB,
+#   RGB, GRBW, or RGBW. The default is GRB.
+initial_RED: 1.0
+initial_GREEN: 0.0
+initial_BLUE: 1.0
+initial_WHITE: 0.0
+#   Sets the initial LED color of the Neopixel. Each value should be
+#   between 0.0 and 1.0. The WHITE option is only available on RGBW
+#   LEDs. The default for each color is 0.#
+
+# Most configuration for the macros can be done by modifying the variables in the _sb_vars macro
+# at the start of this file.
+
+##########
+# MACROS #
+##########
+
+# The following status macros are available (these go inside of your macros):
+#
+#    STATUS_READY
+#    STATUS_OFF
+#    STATUS_BUSY
+#    STATUS_HEATING
+#    STATUS_LEVELING
+#    STATUS_HOMING
+#    STATUS_CLEANING
+#    STATUS_MESHING
+#    STATUS_CALIBRATING_Z
+#
+# With additional macros for basic control:
+#
+#    SET_NOZZLE_LEDS_ON
+#    SET_LOGO_LEDS_OFF
+#    SET_NOZZLE_LEDS_OFF
+#
+# Contributed by Voron discord users wile.e, Tetsunosuke, and etherwalker
+
+[gcode_macro _sb_vars]
+# Color name to RGBW map. Add any other here and call them in the macros below.
+# If a color name is called that is not in the below variable, it will default to white.
+variable_colors: {
+#       'example':    [R  , G  , B  , W  ] 
+        'white':      [204, 204, 204, 255],
+        'red':        [255, 0,   0,   0  ],
+        'green':      [0,   255, 0,   0  ],
+        'blue':       [0,   0  , 255, 0  ],
+        'yellow':     [255, 255, 0,   0  ],
+        'purple':     [255, 0  , 255, 0  ],
+        'pink':       [255, 105, 181, 0  ],
+        'orange':     [255, 165, 0  , 0  ],
+        'gold':       [212, 176, 56 , 0  ],
+        'chartreuse': [223, 255, 0  , 0  ],
+        'off':        [0  , 0  , 0  , 0  ],
+    }
+
+variable_logo_led_name:         "sb_leds" 
+# The name of the addressable LED chain that contains the logo LED(s)
+variable_logo_idx:              "1" 
+# A comma-separated list of indexes LEDs in the logo
+variable_nozzle_led_name:       "sb_leds"
+# The name of the addressable LED chain that contains the nozzle LED(s). This will
+# typically be the same LED chain as the logo.
+variable_nozzle_idx:            "2,3"
+# A comma-separated list of indexes of LEDs in the nozzle
+gcode:
+    # This section is required.  Do Not Delete.
+
+[gcode_macro _set_sb_leds]
+gcode:
+    {% set red = params.RED|default(0)|float %}
+    {% set green = params.GREEN|default(0)|float %}
+    {% set blue = params.BLUE|default(0)|float %}
+    {% set white = params.WHITE|default(0)|float %}
+    {% set led = params.LED|string %}
+    {% set idx = (params.IDX|string).split(',') %}
+    {% set transmit_last = params.TRANSMIT|default(1) %}
+    
+    {% for led_index in idx %}
+        {% set transmit=transmit_last if loop.last else 0 %}
+        set_led led={led} red={red} green={green} blue={blue} white={white} index={led_index} transmit={transmit}
+    {% endfor %}
+
+[gcode_macro _set_sb_leds_by_name]
+gcode:
+    {% set leds_name = params.LEDS %}
+    {% set color_name = params.COLOR|default("white") %}
+    {% set color_name = color_name if color_name in printer["gcode_macro _sb_vars"].colors else "white" %}
+    {% set color = printer["gcode_macro _sb_vars"].colors[color_name]%}
+    {% set led = printer["gcode_macro _sb_vars"][leds_name + "_led_name"] %}
+    {% set idx = printer["gcode_macro _sb_vars"][leds_name + "_idx"] %}
+    {% set transmit = params.TRANSMIT|default(1) %}
+
+    _set_sb_leds led={led} red={color[0] / 255} green={color[1] / 255} blue={color[2] / 255} white={color[3] / 255} idx="{idx}" transmit={transmit}
+
+[gcode_macro set_logo_leds_off]
+gcode:
+    {% set transmit=params.TRANSMIT|default(1) %}
+    _set_sb_leds_by_name leds="logo" color="off" transmit={transmit}
+
+[gcode_macro set_logo_leds_on]
+gcode:
+    {% set transmit=params.TRANSMIT|default(1) %}
+    {% set color=params.COLOR|default("white") %}
+    _set_sb_leds_by_name leds="logo" color={color} transmit={transmit}
+
+[gcode_macro set_nozzle_leds_on]
+gcode:
+    {% set transmit=params.TRANSMIT|default(1) %}
+    {% set color=params.COLOR|default("white") %}
+    _set_sb_leds_by_name leds="nozzle" color={color} transmit={transmit}
+
+[gcode_macro set_nozzle_leds_off]
+gcode:
+    {% set transmit=params.TRANSMIT|default(1) %}
+    _set_sb_leds_by_name leds="nozzle" color="off" transmit={transmit}
+
+[gcode_macro status_off]
+gcode:
+    set_logo_leds_off transmit=0
+    set_nozzle_leds_off
+
+[gcode_macro status_ready]
+gcode:
+    _set_sb_leds_by_name leds="logo" color="purple" transmit=0
+    _set_sb_leds_by_name leds="nozzle" color="purple" transmit=1
+
+[gcode_macro status_busy]
+gcode:
+    _set_sb_leds_by_name leds="logo" color="yellow" transmit=0
+    _set_sb_leds_by_name leds="nozzle" color="white" transmit=1
+
+[gcode_macro status_heating]
+gcode:
+    _set_sb_leds_by_name leds="logo" color="red" transmit=0
+    _set_sb_leds_by_name leds="nozzle" color="red" transmit=1
+
+[gcode_macro status_leveling]
+gcode:
+    _set_sb_leds_by_name leds="logo" color="white" transmit=0
+    _set_sb_leds_by_name leds="nozzle" color="white" transmit=1
+
+[gcode_macro status_homing]
+gcode:
+    _set_sb_leds_by_name leds="logo" color="pink" transmit=0
+    _set_sb_leds_by_name leds="nozzle" color="pink" transmit=1
+
+[gcode_macro status_cleaning]
+gcode:
+    _set_sb_leds_by_name leds="logo" color="chartreuse" transmit=0
+    _set_sb_leds_by_name leds="nozzle" color="white" transmit=1
+
+[gcode_macro status_meshing]
+gcode:
+    _set_sb_leds_by_name leds="logo" color="orange" transmit=0
+    _set_sb_leds_by_name leds="nozzle" color="white" transmit=1
+
+[gcode_macro status_calibrating_z]
+gcode:
+    _set_sb_leds_by_name leds="logo" color="blue" transmit=0
+    _set_sb_leds_by_name leds="nozzle" color="white" transmit=1
+
+[gcode_macro status_printing]
+gcode:
+    _set_sb_leds_by_name leds="logo" color="gold" transmit=0
+    _set_sb_leds_by_name leds="nozzle" color="white" transmit=1
+
+[gcode_macro status_paused]
+gcode:
+    _set_sb_leds_by_name leds="logo" color="green" transmit=0
+    _set_sb_leds_by_name leds="nozzle" color="green" transmit=1


### PR DESCRIPTION
Update to allow calling colors by name, and to allow configuring a color using the traditional 255 based decimal codes.
This also allows the "set_**_leds_on" macros to be called from the frontend with a color name.

I'm not sure if this is the right place to submit this, or if it would even be wanted, but I find it a lot easier to setup the colors and configure the macros this way.