### PR TITLE
Update Phaetus hotends screw dimensions

### DIFF
--- a/STLs/Stealthburner/Printheads/phaetus_rapido/README.md
+++ b/STLs/Stealthburner/Printheads/phaetus_rapido/README.md
@@ -6,7 +6,7 @@
 - One rear printed part
 - Heatset inserts
 - Four M2.5x8 socket screws, which should be provided in your Rapido kit
-- Two M3x12 socket screws
+- Two M3x16 socket screws
 - PTFE tube
 
 ### Instructions
@@ -15,7 +15,7 @@
 - Remove the adapter and bowden collet from the Rapido's heatsink by unscrewing the two M2.5x5 screws:
   ![Remove adapter](Remove_Adapter.png)
 - Place the hotend in the front printed part and secure it by screwing two M2.5x8 screws into the heatsink.
-- Secure the front and rear printed parts together with two M3x12 screws.
+- Secure the front and rear printed parts together with two M3x16 screws.
 - Secure the hotend with the rear part by screwing two M2.5x8 screws into the heatsink.
 - Insert the PFTE tube at the top of the mount.
 

--- a/STLs/Stealthburner/Printheads/phaetus_rapido_v2/README.md
+++ b/STLs/Stealthburner/Printheads/phaetus_rapido_v2/README.md
@@ -6,7 +6,7 @@
 - One rear printed part
 - Heatset inserts
 - Four M2.5x8 socket screws, which should be provided in your Rapido kit
-- Two M3x12 socket screws
+- Two M3x16 socket screws
 - PTFE tube
 
 ### Instructions
@@ -15,7 +15,7 @@
 - Remove the adapter and bowden collet from the Rapido's heatsink by unscrewing the two M2.5x5 screws:
   ![Remove adapter](../phaetus_rapido/Remove_Adapter.png)
 - Place the hotend in the front printed part and secure it by screwing two M2.5x8 screws into the heatsink.
-- Secure the front and rear printed parts together with two M3x12 screws.
+- Secure the front and rear printed parts together with two M3x16 screws.
 - Secure the hotend with the rear part by screwing two M2.5x8 screws into the heatsink.
 - Insert the PFTE tube at the top of the mount.
 


### PR DESCRIPTION
As per the discussion in #77 and related update in #88, printhead screws should be `M3x16`, not `M3x12`.

There are 3 more mentions of `M3x12` in [Printheads/README.md](https://github.com/VoronDesign/Voron-Stealthburner/blob/8bcb9c246fac19d8ac03931ef97fa07c5e5f0f2b/STLs/Stealthburner/Printheads/README.md):

| Hotend | Compatible Parts | Mounting Hardware | Notes |
| :--------: | :--------: | :--------: | :--------: 
| Chube Compact | (Chube_Compact) | 4x M3x12mm  |  |
| Phaetus BMS (6 fins) | (P-BMS6) | 2x M3x12mm | Phaetus has two versions of the BMS; Count the number of fins on your hotend to determine your version. |
| Phaetus BMS (7 fins) | (P-BMS7) | 2x M3x12mm | Phaetus has two versions of the BMS; Count the number of fins on your hotend to determine your version. |

I am not if these need updating as well.